### PR TITLE
Return TEMPFAIL upon SERVFAIL

### DIFF
--- a/openpgpkey-milter
+++ b/openpgpkey-milter
@@ -299,8 +299,8 @@ class myMilter(Milter.Base):
                 syslog("unbound openpgpkey lookup for '%s' returned non-zero status, deferring" % recipient)
                 return Milter.TEMPFAIL
             if wkd_key is None and result.rcode_str == 'serv fail':
-                syslog("unbound openpgpkey lookup for '%s' returned SERVFAIL - letting go plaintext" % recipient)
-                return Milter.CONTINUE
+                syslog("unbound openpgpkey lookup for '%s' returned SERVFAIL, deferring" % recipient)
+                return Milter.TEMPFAIL
             if wkd_key is None and result.bogus:
                 syslog("unbound openpgpkey lookup for '%s' returned with INVALID DNSSEC data, deferring" % recipient)
                 return Milter.TEMPFAIL


### PR DESCRIPTION
Currently, the OpenPGP milter enables an attacker to bypass OpenPGP encryption by performing a DoS attack resulting in a SERVFAIL response. It is therefore better to treat a SERVFAIL response like failed DNSSEC authentication.